### PR TITLE
Look for dot in $PATH

### DIFF
--- a/Dot.m
+++ b/Dot.m
@@ -13,30 +13,16 @@
 
 +(NSData *)dataFromDotFile: (NSURL *) dotFile
 {
-    NSTask *task;
-    task = [[NSTask alloc] init];
-    [task setLaunchPath: @"/usr/bin/dot"];
-	
-    NSArray *arguments;	
-	NSString *dotPath = [dotFile path];
-	
-	NSLog(@"Path: %@",dotPath);
-	
-	
-    arguments = [NSArray arrayWithObjects:dotPath, @"-Tpng", nil];
-    [task setArguments: arguments];
-	
-    NSPipe *pipe;
-    pipe = [NSPipe pipe];
+    NSPipe *pipe = [NSPipe pipe];
+    NSTask *task = [[[NSTask alloc] init] autorelease];
+    
+    [task setLaunchPath: @"/usr/bin/env"];
+    [task setArguments: [NSArray arrayWithObjects: @"dot", [dotFile path], @"-Tpng", nil]];
     [task setStandardOutput: pipe];
-	
-    NSFileHandle *file;
-    file = [pipe fileHandleForReading];
-	
+    
     [task launch];
-	
-	[task autorelease];
-	return [file readDataToEndOfFile];
+    
+    return [[pipe fileHandleForReading] readDataToEndOfFile];
 }
 
 


### PR DESCRIPTION
Hi,

I changed the code to not expect the dot command at /usr/bin/dot - this way, it works out of the box with the GraphViz binary package.
If you don't like my coding style and therefore don't want to pull my change, you could also just change the "setLaunchPath:" argument to @"/usr/bin/env", and add @"dot" as the first object to the arguments array.
